### PR TITLE
Bugfix/None Telemetry observer provider needs two arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "rndi-python-telemetry-observer"
-version = "1.0.0"
+version = "1.1.2"
 description = "Provide an observer contract to work with telemetry. By default includes an AzureInsights observer."
-authors = ["Sergio Palacio Ródenas <sergio.palaciorodenas@cloudblue.com>"]
+authors = ["Sergio Palacio Ródenas <sergio.palaciorodenas@ingrammicro.com>"]
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/rndi/telemetry/adapters/null.py
+++ b/rndi/telemetry/adapters/null.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2023 Ingram Micro. All Rights Reserved.
 #
 from contextlib import contextmanager
-from typing import Any, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, List
 
 from opentelemetry.trace import Span
 from rndi.telemetry.contracts import Observer
@@ -18,7 +18,7 @@ class DummySpan:
         pass
 
 
-def provide_none_telemetry_adapter(_: dict) -> Observer:
+def provide_none_telemetry_adapter(_: dict, __: List[Callable[[], None]] = None) -> Observer:
     return NoneObserverAdapter()
 
 

--- a/rndi/telemetry/provider.py
+++ b/rndi/telemetry/provider.py
@@ -38,7 +38,7 @@ def provide_telemetry_observer(
         adapter = provider(config, automatic_instrumentation)
         logger.debug(f"Telemetry Observer configured with {driver} driver.")
     except Exception as e:
-        adapter = provide_none_telemetry_adapter(config)
+        adapter = provide_none_telemetry_adapter(config, [])
         logger.error(
             f"Telemetry Observer failure, disabling observability with driver {driver} due to: {e}",
         )


### PR DESCRIPTION
* There was a bug when providing none observer due to provider function required one argument but two were passed. It was just a log error because the exception is catched and finnaly the none observer was provided.
* Updated version to 1.1.2