### PR TITLE
Feature/Update Azure monitor to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rndi-python-telemetry-observer"
-version = "1.1.2"
+version = "1.2.0"
 description = "Provide an observer contract to work with telemetry. By default includes an AzureInsights observer."
 authors = ["Sergio Palacio Ródenas <sergio.palaciorodenas@ingrammicro.com>"]
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4"
-azure-monitor-opentelemetry = "^1.0.0-beta.11"
+azure-monitor-opentelemetry = "^1.0.0"
 opentelemetry-sdk = "^1.11.1"
 opentelemetry-instrumentation-requests = "*"
 opentelemetry-instrumentation-psycopg2 = "*"


### PR DESCRIPTION
* Azure monitor is now out of beta, with first stable version 1.0.0, update to use it.